### PR TITLE
fix first dm crash bug

### DIFF
--- a/src/whatschat/GroupManagement.java
+++ b/src/whatschat/GroupManagement.java
@@ -195,9 +195,7 @@ public class GroupManagement{
 	@SuppressWarnings("deprecation")
 	public void connectToGroup(String ip, String friendName) {
 		network.connectToChat(ip); // Connect to chat IP
-		
-		t.stop(); // DIE NOW!
-		
+				
 		//Let's wait for the thread to die
         try {
 			TimeUnit.MILLISECONDS.sleep(1000);

--- a/src/whatschat/WhatsChat.java
+++ b/src/whatschat/WhatsChat.java
@@ -260,7 +260,7 @@ public class WhatsChat extends JFrame implements Performable {
 			    chooser.showOpenDialog(null);
 			    File f = chooser.getSelectedFile();
 			    try {
-			        ImageIcon ii=new ImageIcon(scaleImage(120, 120, ImageIO.read(new File(f.getAbsolutePath()))));//get the image from file chooser and scale it to match JLabel size
+			        ImageIcon ii=new ImageIcon(scaleImage(81, 91, ImageIO.read(new File(f.getAbsolutePath()))));//get the image from file chooser and scale it to match JLabel size
 			        image.setIcon(ii);
 			    } catch (Exception ex) {
 			        ex.printStackTrace();


### PR DESCRIPTION
DM doesn't work for some reason when you start 2 clients, instantly add friends and try to DM.
It will work if you create a group, join a group, then try to dm someone else.

Removing t.stop in GroupManagement.java solves this bug but I don't know what t.stop does so see if this impacts anything else? 