### PR TITLE
adjust dimension of upload to fit frame

### DIFF
--- a/src/whatschat/WhatsChat.java
+++ b/src/whatschat/WhatsChat.java
@@ -260,7 +260,7 @@ public class WhatsChat extends JFrame implements Performable {
 			    chooser.showOpenDialog(null);
 			    File f = chooser.getSelectedFile();
 			    try {
-			        ImageIcon ii=new ImageIcon(scaleImage(120, 120, ImageIO.read(new File(f.getAbsolutePath()))));//get the image from file chooser and scale it to match JLabel size
+			        ImageIcon ii=new ImageIcon(scaleImage(81, 91, ImageIO.read(new File(f.getAbsolutePath()))));//get the image from file chooser and scale it to match JLabel size
 			        image.setIcon(ii);
 			    } catch (Exception ex) {
 			        ex.printStackTrace();


### PR DESCRIPTION
DM doesn't work for some reason when you start 2 clients, instantly add friends and try to DM.
It will work if you create a group, join a group, then try to DM someone else.

Removing **t.stop** in GroupManagement.java connectToGroup function solves this bug but I don't know what t.stop does so see if this impacts anything else? Also, the bug will come back after awhile randomly even after I remove t.stop. Other than this can submit? 